### PR TITLE
Applying patch to 'check the HAT can communicate at init time'

### DIFF
--- a/include/i2c.h
+++ b/include/i2c.h
@@ -42,5 +42,11 @@ extern void i2c_register_firmware_object(PyObject *firmware);
  */
 extern int i2c_reset_hat(void);
 
+/* Checks to see if there has been an error on the comms background
+ * threads.  Returns 0 if all is well, otherwise returns -1 and raises
+ * an appropriate exception.
+ */
+extern int i2c_check_comms_error(void);
+
 
 #endif /* RPI_STRAWBERRY_I2C_H_INCLUDED */

--- a/src/hubmodule.c
+++ b/src/hubmodule.c
@@ -197,7 +197,10 @@ Hub_init(HubObject *self, PyObject *args, PyObject *kwds)
 
     new = firmware_init();
     if (new == NULL)
+    {
+        build_hat_created = 0;
         return -1;
+    }
     old = self->firmware;
     Py_DECREF(old);
     self->firmware = new;
@@ -207,6 +210,13 @@ Hub_init(HubObject *self, PyObject *args, PyObject *kwds)
     Py_BEGIN_ALLOW_THREADS
     usleep(800000);
     Py_END_ALLOW_THREADS
+
+    /* By this time we should at least have heard from the HAT */
+    if (i2c_check_comms_error() < 0)
+    {
+        build_hat_created = 0;
+        return -1;
+    }
 
     return 0;
 }
@@ -221,6 +231,7 @@ Hub_finalize(PyObject *self)
     i2c_close_hat();
     callback_finalize();
     PyErr_Restore(etype, evalue, etraceback);
+    build_hat_created = 0;
 }
 
 

--- a/src/i2c.c
+++ b/src/i2c.c
@@ -68,6 +68,7 @@ static int rx_event_fd = -1;
 static pthread_t comms_rx_thread;
 static pthread_t comms_tx_thread;
 static int shutdown = 0;
+static int heard_from_hat = 0;
 
 static PyObject *firmware_object = NULL;
 
@@ -378,6 +379,21 @@ static void close_wake_gpio(void)
 static void report_comms_error(void)
 {
     /* XXX: Figure out something to do here */
+}
+
+
+/* Called from foreground */
+int i2c_check_comms_error(void)
+{
+    if (!heard_from_hat)
+    {
+        PyErr_SetString(cmd_get_exception(), "HAT not responding");
+        return -1;
+    }
+    /* XXX: else return error code somehow */
+
+    /* Otherwise all is well */
+    return 0;
 }
 
 
@@ -909,6 +925,7 @@ static void *run_comms_rx(void *args __attribute__((unused)))
                 report_comms_error();
                 continue;
             }
+            heard_from_hat = 1;
             if (buffer == NULL)
                 continue; /* Nothing to do */
 


### PR DESCRIPTION
Applying Rhodri's patch, which has the following comment:

After opening I2C comms, makes sure that the HAT has at least
been heard from by the time the BuildHAT object initialisation
finishes.  The latter has a lengthy delay explicitly so that
attached devices can report their existence before initialisation
completes.

Closes #10 