### PR TITLE
fix deadlock with GIL

### DIFF
--- a/src/callback.c
+++ b/src/callback.c
@@ -230,7 +230,9 @@ int callback_finalize(void)
     if (write(cb_event_fd, (uint8_t *)&dummy, 8) < 0)
         rv = 1;
     /* Push on anyway if there is an error */
+    Py_BEGIN_ALLOW_THREADS
     pthread_join(callback_thread, NULL);
+    Py_END_ALLOW_THREADS
 
     return rv;
 }


### PR DESCRIPTION
A finalize function was called, which would have the GIL then it would try to terminate callback thread
and wait on callback thread to finish.  The callback thread would try to get GIL, which would create a deadlock.

Fixed by temporarily releasing the GIL.

Closes #12 