### PR TITLE
double interval for pi zero

### DIFF
--- a/src/i2c.c
+++ b/src/i2c.c
@@ -60,7 +60,7 @@
 #define RESET_GPIO_NUMBER "4"
 #define BOOT0_GPIO_NUMBER "22"
 
-#define INTERVAL 50000000
+#define INTERVAL 100000000
 
 static int gpio_fd = -1;
 static int gpio_state = 0;
@@ -186,7 +186,7 @@ static int set_gpio_direction(const char *direction_pseudofile,
 static int open_writeable_gpio(const char *gpio)
 {
     int fd;
-    struct timespec timeout = { 0, INTERVAL }; /* 50ms */
+    struct timespec timeout = { 0, INTERVAL };
     struct timespec remaining;
     char filename[64];
 
@@ -311,7 +311,7 @@ static int open_wake_gpio(void)
 {
     int fd;
     const char *edge = "both";
-    struct timespec timeout = { 0, INTERVAL }; /* 50ms */
+    struct timespec timeout = { 0, INTERVAL };
     struct timespec remaining;
 
     /* First export the GPIO */


### PR DESCRIPTION
Need longer delay for pi zero to have time for file to be created in /sys

This fixes:

```
PermissionError: [Errno 13] Permission denied
```

When trying to use devices etc.

Closes #24 