### PR TITLE
Update colordistancesensor.rst

### DIFF
--- a/docs/buildhat/colordistancesensor.rst
+++ b/docs/buildhat/colordistancesensor.rst
@@ -5,13 +5,13 @@ ColorDistanceSensor
 
 .. |location_link| raw:: html
 
-   <a href="https://www.lego.com/en-gb/product/color-distance-sensor-88007" target="_blank">LEGO Color and Distance Sensor 45605</a>
+   <a href="https://www.lego.com/en-gb/product/color-distance-sensor-88007" target="_blank">LEGO Color and Distance Sensor 88007</a>
 
 |location_link2|
 
 .. |location_link2| raw:: html
 
-   <a href="https://www.bricklink.com/v2/catalog/catalogitem.page?P=bb0891c01#T=C&C=1" target="_blank">BrinkLink listing</a>
+   <a href="https://www.bricklink.com/v2/catalog/catalogitem.page?P=bb0891c01#T=C&C=1" target="_blank">BrickLink listing</a>
 
 
 The LEGO® Color and Distance Sensor can sort between six different colors and objects within 5 to 10 cm range


### PR DESCRIPTION
Line 8: "45605" product code changed to "88007" in the text of the link. The link itself is going to the correct 88007 product. 45605 is a different sensor referenced elsewhere in the Build HAT documentation.

Line 14: "BrinkLink" changed to "BrickLink" (corrected spelling) in text of the "BrickLink Listing" link.