### PR TITLE
Stop notifying to unblock __init__() after completion

### DIFF
--- a/buildhat/serinterface.py
+++ b/buildhat/serinterface.py
@@ -242,6 +242,7 @@ class BuildHAT:
 
             if uselist and count == 4:
                 with cond:
+                    uselist = False
                     cond.notify()
 
             if not uselist and cmp(line, BuildHAT.DONE):


### PR DESCRIPTION
In the BuildHAT class, __init__() blocks on self.cond to await port enumeration either by the firmware after a reboot or a 'list' command if the firmware is already loaded.  If the firmware is already loaded, count will always be 4 after the list is done enumerating and the boolean will always be true, causing the cond.notify() to be called on *every* serial line input received on loop(), which is unnecessary after the first one.

This patch sets uselist to False after the first notification to stop subsequent calls to notify(), since the boolean and the conditional are only used once by __init__()