### PR TITLE
Add the ability to set Matrix pixels white

### DIFF
--- a/buildhat/matrix.py
+++ b/buildhat/matrix.py
@@ -60,12 +60,14 @@ class Matrix(Device):
             return 8
         elif colorstr == "red":
             return 9
+        elif colorstr == "white":
+            return 10
         raise MatrixInvalidPixel("Invalid color specified")
 
     def clear(self, pixel=None):
         """Clear matrix or set all as the same pixel
 
-        :param pixel: tuple of colour (0–9) or string and brightness (0–10)
+        :param pixel: tuple of colour (0–10) or string and brightness (0–10)
         """
         if pixel is None:
             self._matrix = [[(0,0) for x in range(3)] for y in range(3)]
@@ -77,7 +79,7 @@ class Matrix(Device):
                     c = self.strtocolor(c)
                 if not (brightness >= 0 and brightness <= 10):
                     raise MatrixInvalidPixel("Invalid brightness specified")
-                if not (c >= 0 and c <= 9):
+                if not (c >= 0 and c <= 10):
                     raise MatrixInvalidPixel("Invalid pixel specified")
                 color = (c, brightness)
             else:
@@ -89,7 +91,7 @@ class Matrix(Device):
         """Write pixel to coordinate
 
         :param coord: (0,0) to (2,2)
-        :param pixel: tuple of colour (0–9) or string and brightness (0–10)
+        :param pixel: tuple of colour (0–10) or string and brightness (0–10)
         :param display: Whether to update matrix or not
         """
         if isinstance(pixel, tuple):
@@ -98,7 +100,7 @@ class Matrix(Device):
                 c = self.strtocolor(c)
             if not (brightness >= 0 and brightness <= 10):
                 raise MatrixInvalidPixel("Invalid brightness specified")
-            if not (c >= 0 and c <= 9):
+            if not (c >= 0 and c <= 10):
                 raise MatrixInvalidPixel("Invalid pixel specified")
             color = (c, brightness)
         else:

--- a/docs/buildhat/matrix.rst
+++ b/docs/buildhat/matrix.rst
@@ -35,6 +35,8 @@ Colours may be passed as string or integer parameters.
      - orange
    * - 9
      - red
+   * - 10
+     - white
 
 .. autoclass:: buildhat.Matrix
    :members:


### PR DESCRIPTION
The serial documentation lists 0xA as a valid color for white, so this patch enables it.  I have tested it with my own device.