### PR TITLE
Expose Matrix Mode 3 "transition" feature

### DIFF
--- a/buildhat/matrix.py
+++ b/buildhat/matrix.py
@@ -85,6 +85,40 @@ class Matrix(Device):
             self._matrix = [[color for x in range(3)] for y in range(3)]
         self._output()
 
+    def set_transition(self, transition):
+        """Set the transition mode between pixels
+
+        Use display=False on set_pixel() or use set_pixels() to achieve desired
+        results with transitions.
+
+        Setting a new transition mode will wipe the screen and interrupt any
+        running transition.
+
+        Mode 0: No transition, immediate pixel drawing
+
+        Mode 1: Right-to-left wipe in/out
+
+        If the timing between writing new matrix pixels is less than one second
+        the transition will clip columns of pixels from the right.
+
+        Mode 2: Fade-in/Fade-out
+
+        The fade in and fade out take about 2.2 seconds for full fade effect.
+        Waiting less time between setting new pixels will result in a faster
+        fade which will cause the fade to "pop" in brightness.
+
+        :param transition: Transition mode (0-2)
+        """
+        if not isinstance(transition, int):
+            raise MatrixInvalidPixel("Invalid transition, not integer")
+        if not (transition >= 0 and transition <= 2):
+            raise MatrixInvalidPixel("Invalid transition specified")
+        self.mode(3)
+        self.select()
+        self._write1([0xc3, transition])
+        self.mode(2)  # The rest of the Matrix code seems to expect this to be always set
+        self.deselect()
+
     def set_pixel(self, coord, pixel, display=True):
         """Write pixel to coordinate
 


### PR DESCRIPTION
Add in the ability to toggle transitions on pixel matrix data updates to wipe in/out and fade in/out.

Left out the missing MatrixInvalidPixel in .exc to make merging with the Mode 0 patch easier