### PR TITLE
Matrix stops working when "off" command issued upon deletion

### DIFF
--- a/buildhat/devices.py
+++ b/buildhat/devices.py
@@ -70,7 +70,8 @@ class Device:
             Device._used[self.port] = False
             self._conn.callit = None
             self.deselect()
-            self.off()
+            if self._typeid != 64:
+                self.off()
 
     @property
     def _conn(self):


### PR DESCRIPTION
It stays non-functional until it's reconnected.  This regression was introduced in PR #121 where all devices issue the "off" command to themselves upon destruction.  Using the "off" command is specifically avoided in `BuildHAT.shutdown()` with an exception built into the type identifier for the Matrix but a similar carveout in `Device.__del__()` has not been made.