### PR TITLE
Fix regression in serial port device selection

### DIFF
--- a/buildhat/hat.py
+++ b/buildhat/hat.py
@@ -7,8 +7,11 @@ import weakref
 class Hat:
     """Allows enumeration of devices which are connected to the hat
     """
-    def __init__(self):
-        Device._setup()
+    def __init__(self, device=None):
+        if not device:
+            Device._setup()
+        else:
+            Device._setup(device)
 
     def get(self):
         """Gets devices which are connected or disconnected 


### PR DESCRIPTION
Fix regression from PR #121 to allow the example provided in Issue #102 to work again.

Convention is weird to allow the default to be hard coded only in Device._setup() and not use *args