### PR TITLE
Add debug log filename access

### DIFF
--- a/buildhat/hat.py
+++ b/buildhat/hat.py
@@ -41,6 +41,9 @@ class Hat:
                                           "description": desc}
         return devices
 
+    def get_logfile(self):
+        return Device._instance.debug_filename
+
     def get_vin(self):
         """Get the voltage present on the input power jack
 

--- a/buildhat/hat.py
+++ b/buildhat/hat.py
@@ -42,6 +42,11 @@ class Hat:
         return devices
 
     def get_logfile(self):
+        """Get the filename of the debug log (If enabled, None otherwise)
+
+        :return: Path of the debug logfile
+        :rtype: str or None
+        """
         return Device._instance.debug_filename
 
     def get_vin(self):

--- a/buildhat/serinterface.py
+++ b/buildhat/serinterface.py
@@ -94,8 +94,10 @@ class BuildHAT:
         self.motorqueue = []
         self.fin = False
         self.running = True
+        self.debug_filename = None
         if debug:
             tmp = tempfile.NamedTemporaryFile(suffix=".log", prefix="buildhat-", delete=False)
+            self.debug_filename = tmp.name
             logging.basicConfig(filename=tmp.name, format='%(asctime)s %(message)s',
                                 level=logging.DEBUG)
 


### PR DESCRIPTION
On _some_ platforms, the tempfile module will put the debug log in a non-obvious place such as /private/var/folders/_v/dsfdsljkfds/T instead of something like /tmp.  This patch remembers the filename that gets passed to the logging module so it can be easily located.