### PR TITLE
Start motor with speed argument

### DIFF
--- a/docs/buildhat/passivemotor.py
+++ b/docs/buildhat/passivemotor.py
@@ -7,7 +7,7 @@ from buildhat import PassiveMotor
 motor = PassiveMotor('A')
 
 print("Start motor")
-motor.start()
+motor.start(50)
 time.sleep(3)
 print("Stop motor")
 motor.stop()


### PR DESCRIPTION
found I needed `motor.start(50)` for the Lego train motor to run; with no arguments the motor didn't run and I thought there was an issue with the code, the motor or the BuildHat.